### PR TITLE
Test README example with rdflib

### DIFF
--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,0 +1,2 @@
+output.json
+verify_output.log

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,0 +1,36 @@
+#!/usr/bin/make -f
+
+# This software was developed at the National Institute of Standards
+# and Technology by employees of the Federal Government in the course
+# of their official duties. Pursuant to title 17 Section 105 of the
+# United States Code this software is not subject to copyright
+# protection and is in the public domain. NIST assumes no
+# responsibility whatsoever for its use by other parties, and makes
+# no guarantees, expressed or implied, about its quality,
+# reliability, or any other characteristic.
+#
+# We would appreciate acknowledgement if the software is used.
+
+SHELL = /bin/bash
+
+PYTHON ?= python3.5
+
+all: \
+  check
+
+check: \
+  verify_output.log
+	@echo "Unit tests pass!"
+
+clean:
+	@rm -f from_readme.json verify_from_readme.log
+
+output.json: \
+  example.py
+	$(PYTHON) example.py || rm -f output.json
+
+verify_output.log: \
+  output.json \
+  verify_output.py
+	$(PYTHON) verify_output.py --debug output.json
+	touch $@

--- a/tests/example.py
+++ b/tests/example.py
@@ -1,0 +1,33 @@
+import case
+import datetime
+
+
+document = case.Document()
+
+instrument = document.create_uco_object(
+    'Tool',
+    name='Super Forensic Tool 3000',
+    version='3.4.5',
+    toolType='Extraction',
+    creator='Frank Grimes')
+
+performer = document.create_uco_object('Identity')
+performer.create_property_bundle(
+    'SimpleName',
+    givenName='John',
+    familyName='Doe')
+
+action = document.create_uco_object(
+    'ForensicAction',
+    startTime=datetime.datetime(2017, 7, 21, 13, 32),
+    endTime=datetime.datetime(2017, 7, 21, 14, 12))
+action.create_property_bundle(
+    'ActionReferences',
+    performer=performer,
+    instrument=instrument,
+    # object and result should be filled with
+    # input and output uco objects for this Forensic action.
+    object=None,
+    result=[])
+
+document.serialize(format='json-ld', destination='output.json')

--- a/tests/verify_output.py
+++ b/tests/verify_output.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+
+# This software was developed at the National Institute of Standards
+# and Technology by employees of the Federal Government in the course
+# of their official duties. Pursuant to title 17 Section 105 of the
+# United States Code this software is not subject to copyright
+# protection and is in the public domain. NIST assumes no
+# responsibility whatsoever for its use by other parties, and makes
+# no guarantees, expressed or implied, about its quality,
+# reliability, or any other characteristic.
+#
+# We would appreciate acknowledgement if the software is used.
+
+__version__ = "0.1.0"
+
+import logging
+import os
+
+_logger = logging.getLogger(os.path.basename(__file__))
+
+import rdflib
+
+def main():
+    g = rdflib.Graph()
+    g.parse(args.in_json, format="json-ld")
+    _logger.debug("len(g) = %d." % len(g))
+    assert len(g) > 0
+
+if __name__ == "__main__":
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-d", "--debug", action="store_true")
+    parser.add_argument("in_json")
+    args = parser.parse_args()
+    logging.basicConfig(level=logging.DEBUG if args.debug else logging.INFO)
+    main()


### PR DESCRIPTION
This patch copies the example code from the README, runs it, and then attempts to parse the JSON-LD with rdflib.  The graph, however, appears to be empty.

It's pretty likely this is me missing something obvious.  I'd appreciate any corrective nudges.

Reproduction: `make check` should be run in the `tests/` directory after running the setup instructions in the README.  (The setup instructions work fine for me in a virtualenv.)